### PR TITLE
enhancement: add dry-run and verbose flags

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -17,10 +17,16 @@ type Context struct {
 	ProjectType     TypeOfProject
 	ProjectFilePath string
 	HTTPClient      *http.Client
+
+	// Flags
+	DryRun  bool
+	Verbose bool
 }
 
 var Ctx = Context{
 	ProjectType:     NotSupported,
 	ProjectFilePath: "",
 	HTTPClient:      &http.Client{Timeout: 5 * time.Second},
+	DryRun:          false,
+	Verbose:         false,
 }

--- a/main.go
+++ b/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"flag"
 	"fmt"
-	"github.com/charmbracelet/log"
 	"os"
+
+	"github.com/charmbracelet/log"
 )
 
 // Do not change it (maps in go can't be constants)
@@ -57,7 +59,18 @@ func scanProjectFiles(entries []os.DirEntry, process func(TypeOfProject, string)
 }
 
 func main() {
-	log.SetLevel(log.InfoLevel)
+	log.SetLevel(log.WarnLevel)
+
+	flag.BoolVar(&Ctx.DryRun, "dry-run", false, "Perform a dry run without making any changes")
+	flag.BoolVar(&Ctx.DryRun, "d", false, "Perform a dry run without making any changes (shorthand)")
+	flag.BoolVar(&Ctx.Verbose, "verbose", false, "Enable verbose logging")
+	flag.BoolVar(&Ctx.Verbose, "v", false, "Enable verbose logging (shorthand)")
+
+	flag.Parse()
+
+	if Ctx.Verbose {
+		log.SetLevel(log.DebugLevel)
+	}
 
 	dir, err := os.Getwd()
 	if err != nil {

--- a/npm.go
+++ b/npm.go
@@ -151,10 +151,14 @@ func processNPMPackage(packagePath string) error {
 		return err
 	}
 
-	if err := os.WriteFile(packagePath, append(finalJSON, '\n'), 0644); err != nil {
-		return err
+	if Ctx.DryRun == false {
+		if err := os.WriteFile(packagePath, append(finalJSON, '\n'), 0644); err != nil {
+			return err
+		}
+		log.Infof("Updated %v with final JSON", packagePath)
+	} else {
+		log.Infof("Dry run enabled, not writing changes to %v", packagePath)
 	}
 
-	log.Infof("Updated %v with final JSON", packagePath)
 	return nil
 }


### PR DESCRIPTION
- Introduce DryRun and Verbose flags in Context.
- Parse --dry-run (-d) and --verbose (-v) CLI flags in main.go.
- Adjust logging level when Verbose mode is enabled.
- Make npm.go respect DryRun: skip writes and log purposefully if flagged.

Closes #3 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-dry-run` (`-d`) flag to safely preview changes before applying them to files
  * Added `-verbose` (`-v`) flag to enable detailed debug-level logging for troubleshooting

* **Improvements**
  * Default log level changed from Info to Warning to reduce console noise
  * Debug-level logging details now available when using the verbose flag

<!-- end of auto-generated comment: release notes by coderabbit.ai -->