### PR TITLE
Add patch-only update mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
-.PHONY: test testjs all
+.PHONY: test testjs testjspatch all
 
-all: test testjs
+all: test testjs testjspatch
 
 test:
 	go test ./...
 
 testjs: 
 	cd test_js && go run .. --dry-run --verbose
+
+testjspatch:
+	cd test_js && go run .. --dry-run --verbose --patch-only

--- a/ctx.go
+++ b/ctx.go
@@ -22,8 +22,9 @@ type Context struct {
 	Logger          *log.Logger
 
 	// Flags
-	DryRun  bool
-	Verbose bool
+	DryRun    bool
+	PatchOnly bool
+	Verbose   bool
 }
 
 var Ctx = Context{
@@ -32,5 +33,6 @@ var Ctx = Context{
 	HTTPClient:      &http.Client{Timeout: 5 * time.Second},
 	Logger:          log.Default(),
 	DryRun:          false,
+	PatchOnly:       false,
 	Verbose:         false,
 }

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ func main() {
 
 	flag.BoolVar(&Ctx.DryRun, "dry-run", false, "Perform a dry run without making any changes")
 	flag.BoolVar(&Ctx.DryRun, "d", false, "Perform a dry run without making any changes (shorthand)")
+	flag.BoolVar(&Ctx.PatchOnly, "patch-only", false, "Only update patch versions")
 	flag.BoolVar(&Ctx.Verbose, "verbose", false, "Enable verbose logging")
 	flag.BoolVar(&Ctx.Verbose, "v", false, "Enable verbose logging (shorthand)")
 

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ func main() {
 	flag.BoolVar(&Ctx.DryRun, "dry-run", false, "Perform a dry run without making any changes")
 	flag.BoolVar(&Ctx.DryRun, "d", false, "Perform a dry run without making any changes (shorthand)")
 	flag.BoolVar(&Ctx.PatchOnly, "patch-only", false, "Only update patch versions")
+	flag.BoolVar(&Ctx.PatchOnly, "po", false, "Only update patch versions (shorthand)")
 	flag.BoolVar(&Ctx.Verbose, "verbose", false, "Enable verbose logging")
 	flag.BoolVar(&Ctx.Verbose, "v", false, "Enable verbose logging (shorthand)")
 

--- a/npm.go
+++ b/npm.go
@@ -188,7 +188,7 @@ func updateDependencies(deps []DependencyJSON) ([]DependencyUpdate, error) {
 		}
 
 		if !shouldUpdate {
-			log.Debugf("Dependency %s already up to date (%s)", dep.Name, changeType)
+			log.Debugf("Dependency %s won't update (%s)", dep.Name, changeType)
 			continue
 		}
 
@@ -203,6 +203,9 @@ func updateDependencies(deps []DependencyJSON) ([]DependencyUpdate, error) {
 func classifyDependencyUpdate(currentVersion DependencyVersion, latestVersion DependencyVersion) (SemverChange, bool) {
 	if currentVersion.HasSemver && latestVersion.HasSemver {
 		changeType := currentVersion.Semver.ChangeType(latestVersion.Semver)
+		if Ctx.PatchOnly && (changeType != SemverChangePatch || changeType == SemverChangeRevision) {
+			return changeType, false
+		}
 		return changeType, changeType != SemverChangeNone && changeType != SemverChangeDowngrade
 	}
 

--- a/npm.go
+++ b/npm.go
@@ -213,6 +213,11 @@ func classifyDependencyUpdate(currentVersion DependencyVersion, latestVersion De
 		return SemverChangeNone, false
 	}
 
+	if Ctx.PatchOnly {
+		log.Warnf("Cannot determine change type for non-semver dependency version '%s' -> '%s', skipping update due to patch-only mode", currentVersion.String(), latestVersion.String())
+		return SemverChangeNone, false
+	}
+
 	return SemverChangeInvalid, true
 }
 

--- a/npm.go
+++ b/npm.go
@@ -203,7 +203,7 @@ func updateDependencies(deps []DependencyJSON) ([]DependencyUpdate, error) {
 func classifyDependencyUpdate(currentVersion DependencyVersion, latestVersion DependencyVersion) (SemverChange, bool) {
 	if currentVersion.HasSemver && latestVersion.HasSemver {
 		changeType := currentVersion.Semver.ChangeType(latestVersion.Semver)
-		if Ctx.PatchOnly && (changeType != SemverChangePatch || changeType == SemverChangeRevision) {
+		if Ctx.PatchOnly && changeType != SemverChangePatch {
 			return changeType, false
 		}
 		return changeType, changeType != SemverChangeNone && changeType != SemverChangeDowngrade

--- a/npm.go
+++ b/npm.go
@@ -122,45 +122,37 @@ func getNPMPackageLatestVersion(packageName string) (string, error) {
 	return result.Version, nil
 }
 
-func outputLogger() *log.Logger {
-	if Ctx.Logger != nil {
-		return Ctx.Logger
+func getOtherNPMPackageVersions(packageName string) ([]string, error) {
+	registryURL := "https://registry.npmjs.org/" + url.PathEscape(packageName)
+	client := Ctx.HTTPClient
+	if client == nil {
+		return []string{}, fmt.Errorf("no HTTP client available")
 	}
 
-	return log.Default()
-}
+	resp, err := client.Get(registryURL)
+	if err != nil {
+		return []string{}, fmt.Errorf("request error: %w", err)
+	}
+	defer resp.Body.Close()
 
-func formatDependencyDiff(before DependencyVersion, after DependencyVersion) string {
-	if before.HasSemver && after.HasSemver {
-		if before.Prefix == "" && after.Prefix == "" {
-			return before.Semver.Diff(after.Semver)
-		}
-
-		return fmt.Sprintf("%s -> %s (%s)", before.String(), after.String(), before.Semver.ChangeType(after.Semver))
+	if resp.StatusCode != http.StatusOK {
+		return []string{}, fmt.Errorf("unexpected status: %d", resp.StatusCode)
 	}
 
-	return fmt.Sprintf("%s -> %s", before.String(), after.String())
-}
-
-func (update DependencyUpdate) String() string {
-	return fmt.Sprintf("%s: %s", update.Name, formatDependencyDiff(update.Before, update.After))
-}
-
-func printDependencyUpdates(packagePath string, section string, updates []DependencyUpdate) {
-	if len(updates) == 0 {
-		return
+	var result struct {
+		Time map[string]string `json:"time"`
 	}
 
-	action := "Updated"
-	if Ctx.DryRun {
-		action = "Would update"
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return []string{}, fmt.Errorf("JSON decode error: %w", err)
 	}
 
-	logger := outputLogger()
-	logger.Print(action + " " + section + " in " + packagePath + ":")
-	for _, update := range updates {
-		logger.Print("- " + update.String())
+	versions := make([]string, 0, len(result.Time))
+	for version := range result.Time {
+		versions = append(versions, version)
 	}
+
+	return versions, nil
 }
 
 func updateDependencies(deps []DependencyJSON) ([]DependencyUpdate, error) {
@@ -188,8 +180,21 @@ func updateDependencies(deps []DependencyJSON) ([]DependencyUpdate, error) {
 		}
 
 		if !shouldUpdate {
-			log.Debugf("Dependency %s won't update (%s)", dep.Name, changeType)
-			continue
+			if !Ctx.PatchOnly || !dep.Version.HasSemver {
+				log.Debugf("Dependency %s won't update (%s)", dep.Name, changeType)
+				continue
+			}
+
+			patchVersion, ok, err := getLatestPatchNPMPackageVersion(dep.Name, dep.Version)
+			if err != nil {
+				return nil, fmt.Errorf("failed to fetch other versions for %s: %w", dep.Name, err)
+			}
+			if !ok {
+				log.Debugf("Dependency %s has no available patch update", dep.Name)
+				continue
+			}
+
+			latestVersion = patchVersion
 		}
 
 		updatedVersion := mergeDependencyVersion(dep.Version, latestVersion)
@@ -198,6 +203,30 @@ func updateDependencies(deps []DependencyJSON) ([]DependencyUpdate, error) {
 		deps[i] = dep
 	}
 	return updates, nil
+}
+
+func getLatestPatchNPMPackageVersion(packageName string, currentVersion DependencyVersion) (DependencyVersion, bool, error) {
+	versions, err := getOtherNPMPackageVersions(packageName)
+	if err != nil {
+		return DependencyVersion{}, false, err
+	}
+
+	var latestPatch DependencyVersion
+	foundPatch := false
+	for _, version := range versions {
+		versionToCheck := parseDependencyVersion(version)
+		changeTypeForVersionToCheck, shouldUpdateForVersionToCheck := classifyDependencyUpdate(currentVersion, versionToCheck)
+		if !shouldUpdateForVersionToCheck || changeTypeForVersionToCheck != SemverChangePatch {
+			continue
+		}
+
+		if !foundPatch || latestPatch.Semver.LessThan(versionToCheck.Semver) {
+			latestPatch = versionToCheck
+			foundPatch = true
+		}
+	}
+
+	return latestPatch, foundPatch, nil
 }
 
 func classifyDependencyUpdate(currentVersion DependencyVersion, latestVersion DependencyVersion) (SemverChange, bool) {
@@ -247,6 +276,47 @@ func depsToMap(deps []DependencyJSON) map[string]string {
 		depsMap[dep.Name] = dep.Version.String()
 	}
 	return depsMap
+}
+
+func outputLogger() *log.Logger {
+	if Ctx.Logger != nil {
+		return Ctx.Logger
+	}
+
+	return log.Default()
+}
+
+func formatDependencyDiff(before DependencyVersion, after DependencyVersion) string {
+	if before.HasSemver && after.HasSemver {
+		if before.Prefix == "" && after.Prefix == "" {
+			return before.Semver.Diff(after.Semver)
+		}
+
+		return fmt.Sprintf("%s -> %s (%s)", before.String(), after.String(), before.Semver.ChangeType(after.Semver))
+	}
+
+	return fmt.Sprintf("%s -> %s", before.String(), after.String())
+}
+
+func (update DependencyUpdate) String() string {
+	return fmt.Sprintf("%s: %s", update.Name, formatDependencyDiff(update.Before, update.After))
+}
+
+func printDependencyUpdates(packagePath string, section string, updates []DependencyUpdate) {
+	if len(updates) == 0 {
+		return
+	}
+
+	action := "Updated"
+	if Ctx.DryRun {
+		action = "Would update"
+	}
+
+	logger := outputLogger()
+	logger.Print(action + " " + section + " in " + packagePath + ":")
+	for _, update := range updates {
+		logger.Print("- " + update.String())
+	}
 }
 
 func processNPMPackage(packagePath string) error {

--- a/npm.go
+++ b/npm.go
@@ -126,7 +126,7 @@ func getOtherNPMPackageVersions(packageName string) ([]string, error) {
 	registryURL := "https://registry.npmjs.org/" + url.PathEscape(packageName)
 	client := Ctx.HTTPClient
 	if client == nil {
-		return []string{}, fmt.Errorf("no HTTP client available")
+		client = http.DefaultClient
 	}
 
 	resp, err := client.Get(registryURL)
@@ -140,15 +140,15 @@ func getOtherNPMPackageVersions(packageName string) ([]string, error) {
 	}
 
 	var result struct {
-		Time map[string]string `json:"time"`
+		Versions map[string]json.RawMessage `json:"versions"`
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return []string{}, fmt.Errorf("JSON decode error: %w", err)
 	}
 
-	versions := make([]string, 0, len(result.Time))
-	for version := range result.Time {
+	versions := make([]string, 0, len(result.Versions))
+	for version := range result.Versions {
 		versions = append(versions, version)
 	}
 

--- a/npm_test.go
+++ b/npm_test.go
@@ -334,6 +334,54 @@ func TestGetNPMPackageLatestVersion(t *testing.T) {
 	})
 }
 
+func TestGetOtherNPMPackageVersions(t *testing.T) {
+	t.Run("uses versions metadata only", func(t *testing.T) {
+		client := newRegistryClient(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = io.WriteString(w, `{
+				"time":{"created":"2020-01-01T00:00:00.000Z","modified":"2020-01-02T00:00:00.000Z","1.0.0":"2020-01-01T00:00:00.000Z"},
+				"versions":{"1.0.0":{},"1.0.1":{}}
+			}`)
+		})
+
+		withTestContext(t, Context{HTTPClient: client})
+
+		versions, err := getOtherNPMPackageVersions("react")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		got := map[string]bool{}
+		for _, version := range versions {
+			got[version] = true
+		}
+		want := map[string]bool{"1.0.0": true, "1.0.1": true}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("expected versions %v, got %v", want, got)
+		}
+	})
+
+	t.Run("falls back to default client", func(t *testing.T) {
+		client := newRegistryClient(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = io.WriteString(w, `{"versions":{"2.0.0":{}}}`)
+		})
+		previousDefaultClient := http.DefaultClient
+		http.DefaultClient = client
+		t.Cleanup(func() {
+			http.DefaultClient = previousDefaultClient
+		})
+
+		withTestContext(t, Context{})
+
+		versions, err := getOtherNPMPackageVersions("react")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !reflect.DeepEqual(versions, []string{"2.0.0"}) {
+			t.Fatalf("expected default client version, got %v", versions)
+		}
+	})
+}
+
 func TestProcessNPMPackage(t *testing.T) {
 	t.Run("updates dependencies and preserves document fields", func(t *testing.T) {
 		tempDir := t.TempDir()

--- a/test_js/package.json
+++ b/test_js/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "adb-wifi": "^0.1.1",
-    "left-pad": "1.1.2"
+    "left-pad": "1.1.2",
+    "@docusaurus/core": "3.6.2-canary-6154",
+    "react": "18.3.0"
   }
 }

--- a/test_js/package.json
+++ b/test_js/package.json
@@ -10,6 +10,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "adb-wifi": "^0.1.1"
+    "adb-wifi": "^0.1.1",
+    "left-pad": "1.1.2"
   }
 }


### PR DESCRIPTION
Closes #4 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--patch-only` command-line flag to restrict dependency updates to patch versions only.

* **Bug Fixes / Improvements**
  * Clarified messaging for dependencies that are not updated (now reports they "won't update").
  * In patch-only mode, non-patch version changes are skipped and non-semver dependencies emit a warning instead of being updated.

* **Tests / Chores**
  * CI/test targets updated to include a patch-only test run.
  * Added a small runtime test dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->